### PR TITLE
Update urls to reflect new resourcehouse.info public site

### DIFF
--- a/public/js/win211-search-plugin-public.js
+++ b/public/js/win211-search-plugin-public.js
@@ -42,9 +42,9 @@ $(document).ready(function(){
 			var geoloc = "&loc=";
 			var amp = "&".replace(/#038;/g,"");
 		console.log(location);
-			$("a[href^='https://www.minnesotahelp.info/Search?']").not("a[href^='https://www.minnesotahelp.info/CHANGEME']")
+			$("a[href^='https://www.resourcehouse.info/win211/Search?']").not("a[href^='https://www.resourcehouse.info/win211/CHANGEME']")
 			.each(function(){
-			this.href = "https://www.minnesotahelp.info/Search?" + $(this).attr('data-relativeurl')+amp+"loc="+location+amp+"geo="+geocoor;
+			this.href = "https://www.resourcehouse.info/win211/Search?" + $(this).attr('data-relativeurl')+amp+"loc="+location+amp+"geo="+geocoor;
 			});
 		},
 		minLength:1

--- a/public/php/demo_keyprocess.php
+++ b/public/php/demo_keyprocess.php
@@ -7,7 +7,7 @@
 	$safekeyword = preg_replace("/ /","+",$safekeyword);
 	//$sendkeyword = "*".$safekeyword."*";
 	//analytics.js: __gaTracker('send', 'event', 'keywordsearch', 'taxname');
-	$url = "https://www.minnesotahelp.info/Search?q=".$safekeyword."&loc=".$location."&geo=".$geocoor ;
+	$url = "https://www.resourcehouse.info/win211/Search?q=".$safekeyword."&loc=".$location."&geo=".$geocoor ;
 		while (ob_get_status()) 
 		{
 		    ob_end_clean();

--- a/urlconvert.js
+++ b/urlconvert.js
@@ -11,9 +11,9 @@ var domain = "www.resourcehouse.com/win211"
 var geoloc = "&loc="
 var amp = "&".replace(/#038;/g,"")
 console.log(location);
-jQuery("a[href^='https://www.minnesotahelp.info/Search?']").not("a[href^='https://www.minnesotahelp.info/CHANGEME']")
+jQuery("a[href^='https://www.resourcehouse.info/win211/Search?']").not("a[href^='https://www.resourcehouse.info/win211/CHANGEME']")
 .each(function(){
-this.href = "https://www.minnesotahelp.info/Search?" + jQuery(this).attr('data-relativeurl')+amp+"loc="+location+amp+"geo="+geocoor;
+this.href = "https://www.resourcehouse.info/win211/Search?" + jQuery(this).attr('data-relativeurl')+amp+"loc="+location+amp+"geo="+geocoor;
 })
 		},
 		minLength:1


### PR DESCRIPTION
This fix addresses issue #12 and makes the default site www.resourcehouse.info/win211 ratherthan the minnesotahelp.info testing site.
